### PR TITLE
Added noCursorTimeout option to aggregates.

### DIFF
--- a/lib/mongo-model.js
+++ b/lib/mongo-model.js
@@ -1421,6 +1421,8 @@ class MongoModel extends SchemaModel {
 	 *   @param {Number} [options.scanLimit] - Maximum number of results passing the filter stage that
 	 *     are scanned to aggregate.
 	 *   @param {Number} [options.timeout] - Maximum time for the operation, in seconds.
+	 *   @param {Boolean} [options.noCursorTimeout] - Avoid closing a cursor automatically
+	 *     after 10 minutes of inactivity.
 	 * @return {Promise{Array{Object}}} - Resolves to table of aggregate results, in the commonQuery syntax
 	 * @since v0.1.0
 	 */
@@ -1448,7 +1450,10 @@ class MongoModel extends SchemaModel {
 						delete options.timeout;
 					}
 
-					return collection.aggregate(pipelineData.pipeline, options).toArray()
+					let cursor = collection.aggregate(pipelineData.pipeline, options);
+					if (options.noCursorTimeout) cursor = cursor.noCursorTimeout();
+
+					return cursor.toArray()
 						.catch((err) => { throw MongoError.fromMongoError(err); })
 						.then((results) => {
 							pipelineData.results = results;

--- a/lib/mongo-model.js
+++ b/lib/mongo-model.js
@@ -534,8 +534,7 @@ class MongoModel extends SchemaModel {
 			tailable: options.tailable,
 			awaitdata: options.awaitdata,
 			numberOfRetries: options.numberOfRetries,
-			tailableRetryInterval: options.tailableRetryInterval,
-			timeout: (_.isBoolean(options.canCursorTimeout)) ? options.canCursorTimeout : true
+			tailableRetryInterval: options.tailableRetryInterval
 		};
 		let cursor = collection.find(query, cursorOptions);
 		// Workaround for awful MongoDB streams issue
@@ -544,13 +543,9 @@ class MongoModel extends SchemaModel {
 			this.close();
 		};
 
-		if (_.isNumber(options.skip)) {
-			cursor = cursor.skip(options.skip);
-		}
-
-		if (_.isNumber(options.limit)) {
-			cursor = cursor.limit(options.limit);
-		}
+		if (options.canCursorTimeout === false) cursor = cursor.noCursorTimeout();
+		if (_.isNumber(options.skip)) cursor = cursor.skip(options.skip);
+		if (_.isNumber(options.limit)) cursor = cursor.limit(options.limit);
 
 		if (_.isArray(options.fields)) {
 			if (!_.includes(options.fields, '__rev')) options.fields.push('__rev');
@@ -1421,8 +1416,7 @@ class MongoModel extends SchemaModel {
 	 *   @param {Number} [options.scanLimit] - Maximum number of results passing the filter stage that
 	 *     are scanned to aggregate.
 	 *   @param {Number} [options.timeout] - Maximum time for the operation, in seconds.
-	 *   @param {Boolean} [options.noCursorTimeout] - Avoid closing a cursor automatically
-	 *     after 10 minutes of inactivity.
+	 *   @param {Boolean} [options.canCursorTimeout=true] - Whether the cursor may time out.
 	 * @return {Promise{Array{Object}}} - Resolves to table of aggregate results, in the commonQuery syntax
 	 * @since v0.1.0
 	 */
@@ -1451,7 +1445,7 @@ class MongoModel extends SchemaModel {
 					}
 
 					let cursor = collection.aggregate(pipelineData.pipeline, options);
-					if (options.noCursorTimeout) cursor = cursor.noCursorTimeout();
+					if (options.canCursorTimeout === false) cursor = cursor.noCursorTimeout();
 
 					return cursor.toArray()
 						.catch((err) => { throw MongoError.fromMongoError(err); })


### PR DESCRIPTION
This was really easy.  Aggregates were already using cursors, just immediately calling `toArray` on them.