### PR TITLE
Fixed a bug.

### DIFF
--- a/lib/utils/ops.js
+++ b/lib/utils/ops.js
@@ -37,7 +37,7 @@ exports.addComment = function(query, comment) {
  */
 exports.getQuery = function(op) {
 	let { query } = op;
-	return (query.getMore) ? op.originatingCommand : query;
+	return (query && query.getMore) ? op.originatingCommand : query;
 };
 
 /**


### PR DESCRIPTION
`/cc` @beretem @sripberger 

Fixes the following issue:

```
(node:1734) TypeError: Cannot read property 'getMore' of undefined
    at Object.exports.getQuery (/home/zipscene/lib/node_modules/zs-dmp/node_modules/unimodel-mongo/dist/lib/utils/ops.js:49:15)
    at Object.exports.hasComment (/home/zipscene/lib/node_modules/zs-dmp/node_modules/unimodel-mongo/dist/lib/utils/ops.js:110:23)
    at Object.exports.getOpIdsWithComment (/home/zipscene/lib/node_modules/zs-dmp/node_modules/unimodel-mongo/dist/lib/utils/ops.js:139:17)
    at /home/zipscene/lib/node_modules/zs-dmp/node_modules/unimodel-mongo/dist/lib/mongo-db.js:366:20
    at process._tickDomainCallback (internal/process/next_tick.js:129:7)
```